### PR TITLE
Adds parent::init()

### DIFF
--- a/src/fields/Telephone.php
+++ b/src/fields/Telephone.php
@@ -73,6 +73,7 @@ class Telephone extends Field implements PreviewableFieldInterface
      */
     public function init()
     {
+        parent::init();
         $this->phoneNumberUtil = PhoneNumberUtil::getInstance();
     }
 


### PR DESCRIPTION
A recent beta of Craft added the INIT event, that other plugins can hook in to. To work with that you'll have to call `parent::init()` in your subclass.