### PR TITLE
Prevent POSTing of embed data preview

### DIFF
--- a/src/templates/_components/fieldtypes/Embed/inputEmbed.twig
+++ b/src/templates/_components/fieldtypes/Embed/inputEmbed.twig
@@ -13,7 +13,8 @@
                 id: name ~ 'EmbedData',
                 name: name ~ '[embedData]',
                 value: value ? value.embedData | json_encode(constant('JSON_PRETTY_PRINT') b-or constant('JSON_UNESCAPED_SLASHES')) : null,
-                class: 'nicetext nsmFields-embed-embedDataInput'
+                class: 'nicetext nsmFields-embed-embedDataInput',
+                disabled: true
             }) }}
         </div>
     {% else %}


### PR DESCRIPTION
Thanks for a really useful plugin. I’m using the Embed fields and noticed that when I saved an entry  with a Vimeo embed in Safari the preview failed to render when the page reloaded. This was coupled with an error in the console:

> The XSS Auditor refused to execute a script in 'http://xyz.test/manage/entries/foo/5-slug' because its source code was found within the request. The auditor was enabled because the server did not send an 'X-XSS-Protection' header.

It looks as though the XSS auditor is picking up on the fact that the Embed Data preview field contains iframe code that is POSTed with the save request, then it detects that Craft tries to output said iframe on the next page, which seems fishy, so it refuses to display the iframe.

Disabling the preview field prevents it from being POSTed and fixes the XSS error, so previews work reliably.