### PR TITLE
Allow phone field to be nullable

### DIFF
--- a/src/models/TelephoneModel.php
+++ b/src/models/TelephoneModel.php
@@ -85,7 +85,7 @@ class TelephoneModel extends Model implements \JsonSerializable
 
         $format = array_key_exists($format, $formats) ? $formats[$format] : $format;
 
-        return $this->phoneNumberUtil->format($this->phoneNumber, $format);
+        return !empty($this->phoneNumber) ? $this->phoneNumberUtil->format($this->phoneNumber, $format) : '';
     }
 
     /**


### PR DESCRIPTION
When using the phone field, it can be set to optional or required in Craft.
The format function failed when a phone field was left empty.

This pull requests attempts to allow empty phone fields. Open to feedback!