### PR TITLE
Add support for plain text field migrations

### DIFF
--- a/src/fields/Embed.php
+++ b/src/fields/Embed.php
@@ -98,8 +98,16 @@ class Embed extends Field implements PreviewableFieldInterface
      */
     public function normalizeValue($value, ElementInterface $element = null)
     {
-        if (is_string($value)) {
-            $value = json_decode($value, true);
+        if(is_string($value)) {
+            // Attempt to migrate any old plain text URL values
+            if (filter_var($value, FILTER_VALIDATE_URL) !== false) {
+                $value = [
+                    'rawInput' => $value,
+                    'embedData' => NsmFields::getInstance()->embed->parse($value)
+                ];
+            } else {
+                $value = json_decode($value, true);
+            }
         }
 
         if (is_array($value) && $value['rawInput']) {


### PR DESCRIPTION
I’ve just migrated an old Craft 2 project to Craft 3 and wanted to convert some old Plain Text fields containing URLs to Embed fields. There was no "Changing this may result in data loss” exclamation mark so I assumed I’d be on safe ground, but although the old data wasn’t touched the Embed field type wasn’t able to parse it either, so when viewing old entries in the CP they appear to have no data in the video field and as soon as the entry was saved the old plain text value was deleted.

This little change adds a check for plain text URLs and normalises them. I’ve verified that it works on the frontend and backend and that existing JSON data is unaffected by the change.

This does mean that frontend requests can trigger slow `embed->parse` calls that I assume normally only happen in the CP, but that’s easily addressed by running `craft resave/entries` to ensure that all of the old text values are migrated to the Embed JSON format.