### PR TITLE
Moved Google Maps API JS callback

### DIFF
--- a/src/assetbundles/addressfield/dist/js/Address.js
+++ b/src/assetbundles/addressfield/dist/js/Address.js
@@ -11,6 +11,12 @@
  */
 
 ;(function ($, Craft, window, document, undefined) {
+  // We need to create a callback for the Google Maps API to use when it has loaded
+    window.googleMapsPlacesApiLoaded = window.googleMapsPlacesApiLoaded || false;
+    window.googleMapsPlacesApiLoadedCallback = function() {
+      window.googleMapsPlacesApiLoaded = true;
+      document.body.dispatchEvent(new Event('googleMapsPlacesApiLoaded'));
+    };
 
     var pluginName = "NsmFieldsAddress",
         defaults = {};

--- a/src/fields/Address.php
+++ b/src/fields/Address.php
@@ -162,6 +162,8 @@ class Address extends Field implements PreviewableFieldInterface
         // Register our asset bundle
         Craft::$app->getView()->registerAssetBundle(AddressFieldAsset::class);
 
+        $this->renderFieldJs();
+
         // Get our id and namespace
         $id = Craft::$app->getView()->formatInputId($this->handle);
         $namespacedId = Craft::$app->getView()->namespaceInputId($id);
@@ -211,8 +213,6 @@ class Address extends Field implements PreviewableFieldInterface
         $fieldLabels = null;
         $addressFields = null;
 
-        $this->renderFieldJs();
-
         $countryCode = $value ? $value->getCountryCode() : $this->defaultCountryCode;
         $countryCodeField = Craft::$app->getView()->renderTemplate(
             'nsm-fields/_components/fieldtypes/Address/input/countryCode',
@@ -251,15 +251,7 @@ class Address extends Field implements PreviewableFieldInterface
     {
         $pluginSettings = NsmFields::getInstance()->getSettings();
 
-        $js = <<<JS
-window.googleMapsPlacesApiLoaded = window.googleMapsPlacesApiLoaded || false;
-function googleMapsPlacesApiLoadedCallback() {
-    window.googleMapsPlacesApiLoaded = true;
-    document.body.dispatchEvent(new Event('googleMapsPlacesApiLoaded'));
-}
-JS;
-        Craft::$app->view->registerJs($js, View::POS_BEGIN);
-
+        // Note: refer to src/assetbundles/addressfield/dist/js/Address.js for the callback name
         $googleApiKey = $pluginSettings->googleApiKey;
         $mapUrl = sprintf(
             'https://maps.googleapis.com/maps/api/js?key=%s&libraries=places&callback=googleMapsPlacesApiLoadedCallback',
@@ -267,7 +259,12 @@ JS;
         );
         Craft::$app->view->registerJsFile(
             $mapUrl,
-            ['async' => '', 'defer' => '', 'position' => View::POS_END]
+            [
+                'async' => '',
+                'defer' => '',
+                'position' => View::POS_END,
+                'depends' => [AddressFieldAsset::class]
+            ]
         );
     }
 


### PR DESCRIPTION
Also made Google Map API JS include depend on the AddressFieldAsset to ensure correct load order.

See issue #50.